### PR TITLE
Create device.md

### DIFF
--- a/PV-Wechselrichter/Sungrow/device.md
+++ b/PV-Wechselrichter/Sungrow/device.md
@@ -1,0 +1,27 @@
+# Sungrow Hybrid Wechselrichter SH8.0RT
+
+---------------------------------------------------------
+
+## Weitere kompatible Sungrow Wechselrichter:
+- SH5K-20
+- SH3K6
+- SH4K6
+- SH5K-V13
+- SH5K-30
+- SH3K6-30
+- SH4K6-30
+- SH5.0RS
+- SH3.6RS
+- SH4.6RS
+- SH6.0RS
+- SH10RT
+- SH8.0RT
+- SH6.0RT
+- SH5.0RT
+
+---------------------------------------------------------
+
+## Einstellungen im Modbus-Adapter:
+
+![Unbenannt](https://user-images.githubusercontent.com/38273154/207982763-34709e36-e280-49e4-9943-6b3d9ab22201.PNG)
+![Unbenannt1](https://user-images.githubusercontent.com/38273154/207982772-a458dd00-75b5-4d54-bf97-0156e2f4c997.PNG)


### PR DESCRIPTION
# Sungrow Hybrid Wechselrichter SH8.0RT

---------------------------------------------------------

## Weitere kompatible Sungrow Wechselrichter:
- SH5K-20
- SH3K6
- SH4K6
- SH5K-V13
- SH5K-30
- SH3K6-30
- SH4K6-30
- SH5.0RS
- SH3.6RS
- SH4.6RS
- SH6.0RS
- SH10RT
- SH8.0RT
- SH6.0RT
- SH5.0RT

---------------------------------------------------------

## Einstellungen im Modbus-Adapter:

![Unbenannt](https://user-images.githubusercontent.com/38273154/207982763-34709e36-e280-49e4-9943-6b3d9ab22201.PNG)
![Unbenannt1](https://user-images.githubusercontent.com/38273154/207982772-a458dd00-75b5-4d54-bf97-0156e2f4c997.PNG)