### PR TITLE
holding-registers for SE10K-RWB, SE30K and SE Home Battery

### DIFF
--- a/PV-Wechselrichter/SolarEdge/README.md
+++ b/PV-Wechselrichter/SolarEdge/README.md
@@ -1,4 +1,4 @@
-# SolarEdge Inverter (e.g. SK8K)
+# SolarEdge Inverter (e.g. SE8K)
 
 ---------------------------------------------------------
 
@@ -20,3 +20,14 @@ Use `holding-registers.tsv`.
 - MTR-240-3PC1-D-A-MW
 
 Use `holding-registers-meter1.tsv`. *Also includes all registers of the inverter.*
+
+## Other SolarEdge inverters and Home Battery
+
+- SE10K-RWB48
+- SE30K
+- SE Home Battery
+
+Use 'holding-registers-S10KRWB-SE30K-Battery.tsv'.
+
+As it is not easy to determine the DC power for SE hybrid inverters, here is the appropriate ioBroker Javascript for the holding register:
+'holding-registers-S10KRWB-SE30K-Battery.js'.

--- a/PV-Wechselrichter/SolarEdge/holding-registers-S10KRWB-SE30K-Battery.js
+++ b/PV-Wechselrichter/SolarEdge/holding-registers-S10KRWB-SE30K-Battery.js
@@ -1,10 +1,10 @@
 
-var last_SE9K_I_DC_Power = 0;
+var last_SE10K_I_DC_Power = 0;
 var last_SE30K_I_DC_Power = 0;
 var last_Battery1_InstantaneousPower = 0;
-var last_SE9K_I_AC_PV_Power = 0;
+var last_SE10K_I_AC_PV_Power = 0;
 var last_I_AC_Power = 0;
-var last_SE9K_I_AC_Power = 0;
+var last_SE10K_I_AC_Power = 0;
 var last_SE30K_I_AC_Power = 0;
 var last_M_AC_Power = 0;
 var tempState;
@@ -16,21 +16,21 @@ function precisionRound(number, precision) {
 }
 
 
-createState('SolarEdge.SE9K.I_AC_Power', {
+createState('SolarEdge.SE10K.I_AC_Power', {
 	name: 'I_AC_Power',
 	unit: 'W',
 	type: 'number',
 	role: 'value.energy'
 });
 
-createState('SolarEdge.SE9K.I_AC_PV_Power', {
+createState('SolarEdge.SE10K.I_AC_PV_Power', {
 	name: 'I_AC_PV_Power',
 	unit: 'W',
 	type: 'number',
 	role: 'value.energy'
 });
 
-createState('SolarEdge.SE9K.I_DC_Power', {
+createState('SolarEdge.SE10K.I_DC_Power', {
 	name: 'I_DC_Power',
 	unit: 'W',
 	type: 'number',
@@ -108,8 +108,8 @@ setState('SolarEdge.Battery1.SOE', last_Battery1_SOE, true);
 last_Battery1_InstantaneousPower = getState('modbus.0.holdingRegisters.1.97717_Battery_1_Instantaneous_Power').val;
 
 // Wechselrichter SE10K-RWB48
-last_SE9K_I_DC_Power = getState('modbus.0.holdingRegisters.1.40101_I_DC_Power').val;
-last_SE9K_I_AC_Power = Math.round(getState('modbus.0.holdingRegisters.1.40084_I_AC_Power').val);
+last_SE10K_I_DC_Power = getState('modbus.0.holdingRegisters.1.40101_I_DC_Power').val;
+last_SE10K_I_AC_Power = Math.round(getState('modbus.0.holdingRegisters.1.40084_I_AC_Power').val);
 
 // Wechselrichter SE30K
 last_SE30K_I_DC_Power = getState('modbus.0.holdingRegisters.2.40101_I_DC_Power').val;
@@ -126,7 +126,7 @@ on({id:/^modbus\.0\.holdingRegisters\.[1-2]\.40084_I_AC_Power$/, change:'ne'}, f
 
     switch(obj.id) {
         case 'modbus.0.holdingRegisters.1.40084_I_AC_Power':
-            last_SE9K_I_AC_Power = Math.round(obj.state.val);
+            last_SE10K_I_AC_Power = Math.round(obj.state.val);
             break;
         case 'modbus.0.holdingRegisters.2.40084_I_AC_Power':
             last_SE30K_I_AC_Power = Math.round(obj.state.val);
@@ -152,7 +152,7 @@ on({id:'modbus.0.holdingRegisters.1.97733_Battery_1_State_of_Energy', change:'ne
 on({id:/^modbus\.0\.holdingRegisters\.[1-2]\.40101_I_DC_Power$/, change:'ne'}, function(obj) {
     switch(obj.id) {
         case 'modbus.0.holdingRegisters.1.40101_I_DC_Power':
-            last_SE9K_I_DC_Power = obj.state.val;
+            last_SE10K_I_DC_Power = obj.state.val;
             break;
         case 'modbus.0.holdingRegisters.2.40101_I_DC_Power':
             last_SE30K_I_DC_Power = obj.state.val;
@@ -169,28 +169,28 @@ on({id:'modbus.0.holdingRegisters.1.40207_M_AC_Power', change:'ne'}, function(ob
 schedule("* * * * * *", function() {
 
     // Aktuelle PV-Leistung DC
-    setState('SolarEdge.SE9K.I_DC_Power', last_SE9K_I_DC_Power, true);
+    setState('SolarEdge.SE10K.I_DC_Power', last_SE10K_I_DC_Power, true);
     setState('SolarEdge.SE30K.I_DC_Power', last_SE30K_I_DC_Power, true);
-    var SE9K_I_DC_PV_Power = last_SE9K_I_DC_Power + last_Battery1_InstantaneousPower;
-    if (SE9K_I_DC_PV_Power < 0) {
-        SE9K_I_DC_PV_Power = 0;
+    var SE10K_I_DC_PV_Power = last_SE10K_I_DC_Power + last_Battery1_InstantaneousPower;
+    if (SE10K_I_DC_PV_Power < 0) {
+        SE10K_I_DC_PV_Power = 0;
     }
-    var SE9K_I_DC_Batt_Power = -1 * Math.round(last_Battery1_InstantaneousPower * 0.976);
+    var SE10K_I_DC_Batt_Power = -1 * Math.round(last_Battery1_InstantaneousPower * 0.976);
 
     // Batterie
     setState('SolarEdge.Battery1.InstantaneousPower', last_Battery1_InstantaneousPower, true);
 
     // Aktuelle PV-Leistung AC
     // I_AC_Power aus I_DC_Power errechnen indem 97,6% Wirkungsgrad (laut Datenblatt) angenommen wird.
-    last_SE9K_I_AC_PV_Power = Math.round(SE9K_I_DC_PV_Power * 0.98);
-    last_I_AC_Power = last_SE9K_I_AC_PV_Power + last_SE30K_I_AC_Power;
-    setState('SolarEdge.SE9K.I_AC_Power', last_SE9K_I_AC_Power, true);
-    setState('SolarEdge.SE9K.I_AC_PV_Power', last_SE9K_I_AC_PV_Power, true);
+    last_SE10K_I_AC_PV_Power = Math.round(SE10K_I_DC_PV_Power * 0.98);
+    last_I_AC_Power = last_SE10K_I_AC_PV_Power + last_SE30K_I_AC_Power;
+    setState('SolarEdge.SE10K.I_AC_Power', last_SE10K_I_AC_Power, true);
+    setState('SolarEdge.SE10K.I_AC_PV_Power', last_SE10K_I_AC_PV_Power, true);
     setState('SolarEdge.SE30K.I_AC_Power', last_SE30K_I_AC_Power, true);
     setState('SolarEdge.I_AC_Power', last_I_AC_Power, true);
 
     // Differenz zwischen PV-Leistung, Batterieleistung und Netzbezug ergibt Eigenverbrauch
-    setState('SolarEdge.Used_Power', last_I_AC_Power + SE9K_I_DC_Batt_Power - last_M_AC_Power, true);
+    setState('SolarEdge.Used_Power', last_I_AC_Power + SE10K_I_DC_Batt_Power - last_M_AC_Power, true);
 
     // Der Zähler gibt die Information, wieviel exportiert/importiert wird
     setState('SolarEdge.M_AC_Power', Math.abs(last_M_AC_Power), true);

--- a/PV-Wechselrichter/SolarEdge/holding-registers-S10KRWB-SE30K-Battery.js
+++ b/PV-Wechselrichter/SolarEdge/holding-registers-S10KRWB-SE30K-Battery.js
@@ -1,0 +1,199 @@
+
+var last_SE9K_I_DC_Power = 0;
+var last_SE30K_I_DC_Power = 0;
+var last_Battery1_InstantaneousPower = 0;
+var last_SE9K_I_AC_PV_Power = 0;
+var last_I_AC_Power = 0;
+var last_SE9K_I_AC_Power = 0;
+var last_SE30K_I_AC_Power = 0;
+var last_M_AC_Power = 0;
+var tempState;
+var last_Battery1_SOE = 0;
+
+function precisionRound(number, precision) {
+  var factor = Math.pow(10, precision);
+  return Math.round(number * factor) / factor;
+}
+
+
+createState('SolarEdge.SE9K.I_AC_Power', {
+	name: 'I_AC_Power',
+	unit: 'W',
+	type: 'number',
+	role: 'value.energy'
+});
+
+createState('SolarEdge.SE9K.I_AC_PV_Power', {
+	name: 'I_AC_PV_Power',
+	unit: 'W',
+	type: 'number',
+	role: 'value.energy'
+});
+
+createState('SolarEdge.SE9K.I_DC_Power', {
+	name: 'I_DC_Power',
+	unit: 'W',
+	type: 'number',
+	role: 'value.energy'
+});
+
+createState('SolarEdge.SE30K.I_AC_Power', {
+	name: 'I_AC_Power',
+	unit: 'W',
+	min:  0,
+	type: 'number',
+	role: 'value.energy'
+});
+
+createState('SolarEdge.SE30K.I_DC_Power', {
+	name: 'I_DC_Power',
+	unit: 'W',
+	min:  0,
+	type: 'number',
+	role: 'value.energy'
+});
+
+createState('SolarEdge.Battery1.InstantaneousPower', {
+	name: 'InstantaneousPower',
+	unit: 'W',
+	type: 'number',
+	role: 'value.energy'
+});
+
+createState('SolarEdge.I_AC_Power', {
+	name: 'PV',
+	unit: 'W',
+	min:  0,
+	type: 'number',
+	role: 'value.energy'
+});
+
+createState('SolarEdge.Used_Power', {
+	name: 'Haus',
+	unit: 'W',
+	min:  0,
+	type: 'number',
+	role: 'value.energy'
+});
+
+createState('SolarEdge.M_AC_Power', {
+	name: 'SolarEdge.M_AC_Power',
+	unit: 'W',
+	type: 'number',
+	role: 'value.energy'
+});
+
+createState('SolarEdge.Import_Export_Status', {
+	name: 'SolarEdge.Import_Export_Status',
+	min:  0,
+	type: 'number'
+});
+
+createState('SolarEdge.Battery1.SOE', {
+	name: 'SOE',
+	unit: '%',
+	min:  0,
+	type: 'number',
+	role: 'value.battery'
+});
+
+
+//
+// Beim Start die Variablen mit den aktuellen Werten füllen
+//
+// Batterie:
+tempState = getState('modbus.0.holdingRegisters.1.97733_Battery_1_State_of_Energy').val;
+last_Battery1_SOE = precisionRound((tempState >= 0 && tempState <= 100) ? tempState : 0, 1);
+setState('SolarEdge.Battery1.SOE', last_Battery1_SOE, true);
+last_Battery1_InstantaneousPower = getState('modbus.0.holdingRegisters.1.97717_Battery_1_Instantaneous_Power').val;
+
+// Wechselrichter SE10K-RWB48
+last_SE9K_I_DC_Power = getState('modbus.0.holdingRegisters.1.40101_I_DC_Power').val;
+last_SE9K_I_AC_Power = Math.round(getState('modbus.0.holdingRegisters.1.40084_I_AC_Power').val);
+
+// Wechselrichter SE30K
+last_SE30K_I_DC_Power = getState('modbus.0.holdingRegisters.2.40101_I_DC_Power').val;
+last_SE30K_I_AC_Power = Math.round(getState('modbus.0.holdingRegisters.2.40084_I_AC_Power').val);
+
+// Einspeise/Bezugszähler
+last_M_AC_Power = getState('modbus.0.holdingRegisters.1.40207_M_AC_Power').val;
+
+//
+// Änderungen erkennen und in die Variablen schreiben
+//
+// AC_Power
+on({id:/^modbus\.0\.holdingRegisters\.[1-2]\.40084_I_AC_Power$/, change:'ne'}, function(obj) {
+
+    switch(obj.id) {
+        case 'modbus.0.holdingRegisters.1.40084_I_AC_Power':
+            last_SE9K_I_AC_Power = Math.round(obj.state.val);
+            break;
+        case 'modbus.0.holdingRegisters.2.40084_I_AC_Power':
+            last_SE30K_I_AC_Power = Math.round(obj.state.val);
+            break;
+    }
+});
+
+// Batterieleistung
+on({id:'modbus.0.holdingRegisters.1.97717_Battery_1_Instantaneous_Power', change:'ne'}, function(obj){
+    last_Battery1_InstantaneousPower = obj.state.val;
+});
+
+// Batterie State of Energy
+on({id:'modbus.0.holdingRegisters.1.97733_Battery_1_State_of_Energy', change:'ne'}, function(obj){
+    var temp = precisionRound((obj.state.val >= 0 && obj.state.val <= 100) ? obj.state.val : -1, 1);
+    if (temp >= 0){
+        last_Battery1_SOE = temp;
+        setState('SolarEdge.Battery1.SOE', last_Battery1_SOE, true);
+    }
+});
+
+// DC-Leistung der Wechselrichter
+on({id:/^modbus\.0\.holdingRegisters\.[1-2]\.40101_I_DC_Power$/, change:'ne'}, function(obj) {
+    switch(obj.id) {
+        case 'modbus.0.holdingRegisters.1.40101_I_DC_Power':
+            last_SE9K_I_DC_Power = obj.state.val;
+            break;
+        case 'modbus.0.holdingRegisters.2.40101_I_DC_Power':
+            last_SE30K_I_DC_Power = obj.state.val;
+            break;
+    }
+});
+
+// Wieviel Leistung wird aktuell aus dem Netz bezogen?
+on({id:'modbus.0.holdingRegisters.1.40207_M_AC_Power', change:'ne'}, function(obj) {
+    last_M_AC_Power = obj.state.val;
+});
+
+// Jede Sekunde die Werte in die Objekte schreiben
+schedule("* * * * * *", function() {
+
+    // Aktuelle PV-Leistung DC
+    setState('SolarEdge.SE9K.I_DC_Power', last_SE9K_I_DC_Power, true);
+    setState('SolarEdge.SE30K.I_DC_Power', last_SE30K_I_DC_Power, true);
+    var SE9K_I_DC_PV_Power = last_SE9K_I_DC_Power + last_Battery1_InstantaneousPower;
+    if (SE9K_I_DC_PV_Power < 0) {
+        SE9K_I_DC_PV_Power = 0;
+    }
+    var SE9K_I_DC_Batt_Power = -1 * Math.round(last_Battery1_InstantaneousPower * 0.976);
+
+    // Batterie
+    setState('SolarEdge.Battery1.InstantaneousPower', last_Battery1_InstantaneousPower, true);
+
+    // Aktuelle PV-Leistung AC
+    // I_AC_Power aus I_DC_Power errechnen indem 97,6% Wirkungsgrad (laut Datenblatt) angenommen wird.
+    last_SE9K_I_AC_PV_Power = Math.round(SE9K_I_DC_PV_Power * 0.98);
+    last_I_AC_Power = last_SE9K_I_AC_PV_Power + last_SE30K_I_AC_Power;
+    setState('SolarEdge.SE9K.I_AC_Power', last_SE9K_I_AC_Power, true);
+    setState('SolarEdge.SE9K.I_AC_PV_Power', last_SE9K_I_AC_PV_Power, true);
+    setState('SolarEdge.SE30K.I_AC_Power', last_SE30K_I_AC_Power, true);
+    setState('SolarEdge.I_AC_Power', last_I_AC_Power, true);
+
+    // Differenz zwischen PV-Leistung, Batterieleistung und Netzbezug ergibt Eigenverbrauch
+    setState('SolarEdge.Used_Power', last_I_AC_Power + SE9K_I_DC_Batt_Power - last_M_AC_Power, true);
+
+    // Der Zähler gibt die Information, wieviel exportiert/importiert wird
+    setState('SolarEdge.M_AC_Power', Math.abs(last_M_AC_Power), true);
+    setState('SolarEdge.Import_Export_Status', last_M_AC_Power > 0 ? 1 : 0, true);
+
+});

--- a/PV-Wechselrichter/SolarEdge/holding-registers-S10KRWB-SE30K-Battery.tsv
+++ b/PV-Wechselrichter/SolarEdge/holding-registers-S10KRWB-SE30K-Battery.tsv
@@ -1,0 +1,100 @@
+_address	deviceId	name	description	unit	type	len	factor	offset	formula	role	room	poll	wp	cw	isScale
+97345	1	Export_Control_Mode	Export Control Mode		uint16be	1	1	0		level		true	false	false	
+97347	1	Export_Control_Site_Limit	Export Control Site Limit	W	floatsw	2	1	0		level		true	false	false	
+97709	1	Battery_1_Average_Temperature	Battery 1 Average Temperature	C°	floatsw	2	1	0		level		true	false	false	
+97711	1	Battery_1_Max_Temperature	Battery 1 Max Temperature	C°	floatsw	2	1	0		level		false	false	false	
+97713	1	Battery_1_Instantaneous_Voltage	Battery 1 Instantaneous Voltage	V	floatsw	2	1	0		level		true	false	false	
+97717	1	Battery_1_Instantaneous_Power	Battery 1 Instantaneous Power	W	floatsw	2	1	0		level		true	false	false	
+97719	1	Battery_1_Lifetime_Export_Energy_Counter	Battery 1 Lifetime Export Energy Counter	Wh	uint32sw	2	1	0		level		true	false	false	
+97723	1	Battery_1_Lifetime_Import_Energy_Counter	Battery 1 Lifetime Import Energy Counter	Wh	uint32sw	2	1	0		level		true	false	false	
+97731	1	Battery_1_State_of_Health	Battery 1 State of Health (SOH)	%	floatsw	2	1	0		level		false	false	false	
+97733	1	Battery_1_State_of_Energy	Battery 1 State of Energy (SOE)	%	floatsw	2	1	0		level		true	false	false	
+97735	1	Battery_1_Status	Battery 1 Status		uint32sw	2	1	0		level		true	false	false	
+97737	1	Battery_1_Status_Internal	Battery 1 Status Internal		uint32sw	2	1	0		level		true	false	false	
+101441	1	RRCR_State	RRCR State		uint16be	1	1	0		level		true	false	false	
+101442	1	Active_Power_Limit	Active Power Limit	%	uint16be	1	1	0		level		true	true	false	
+101697	1	Commit_Power_Control_Settings	Commit Power Control Settings		int16be	1	1	0		level		true	true	false	
+101701	1	ReactivePwrConfig	Reactive Power Config		int32sw	2	1	0		level		true	true	false	
+101763	1	AdvancedPwrControlEn	Advanced Power Control Enable		int32sw	2	1	0		level		true	false	false	
+40005	1	C_Manufacturer	Inverter Manufacturer		string	16	1	0		level		false	false	false	
+40021	1	C_Model	Inverter Model		string	16	1	0		level		false	false	false	
+40045	1	C_Version	Inverter Version		string	8	1	0		level		true	false	false	
+40053	1	C_SerialNumber	Inverter Serial Number		string	16	1	0		level		false	false	false	
+40069	1	C_DeviceAddress	MODBUS Unit ID		uint16be	1	1	0		level		false	false	false	
+40070	1	C_SunSpec_DID	Phases		uint16be	1	1	0		level		false	false	false	
+40072	1	I_AC_Current	AC Current	A	uint16be	1	1	0		level		false	false	false	
+40073	1	I_AC_CurrentA	AC Phase A Current value	A	uint16be	1	1	0		level		false	false	false	
+40074	1	I_AC_CurrentB	AC Phase B Current value	A	uint16be	1	1	0		level		false	false	false	
+40075	1	I_AC_CurrentC	AC Phase C Current value	A	uint16be	1	1	0		level		false	false	false	
+40076	1	I_AC_Current_SF	AC Current scale factor		int16be	1	1	0		level		false	false	false	
+40080	1	I_AC_VoltageAN	AC Voltage Phase A to N value	V	uint16be	1	1	0		level		false	false	false	
+40081	1	I_AC_VoltageBN	AC Voltage Phase B to N value	V	uint16be	1	1	0		level		false	false	false	
+40082	1	I_AC_VoltageCN	AC Voltage Phase C to N value	V	uint16be	1	1	0		level		false	false	false	
+40083	1	I_AC_Voltage_SF	AC Voltage scale factor		int16be	1	1	0		level		false	false	false	
+40084	1	I_AC_Power	AC Power value	W	int16be	1	1	0	x*Math.pow(10,sf['40085'])	level		true	false	false	
+40085	1	I_AC_Power_SF	AC Power scale factor		int16be	1	1	0		level		true	false	false	true
+40086	1	I_AC_Frequency	AC Frequency value	Hz	uint16be	1	1	0		level		false	false	false	
+40087	1	I_AC_Frequency_SF	AC Frequency scale factor		int16be	1	1	0		level		false	false	false	
+40088	1	I_AC_VA	Apparent Power value	VA	int16be	1	1	0		level		false	false	false	
+40089	1	I_AC_VA_SF	Apparent Power scale factor		int16be	1	1	0		level		false	false	false	
+40090	1	I_AC_VAR	Reactive Power	VAR	int16be	1	1	0		level		false	false	false	
+40091	1	I_AC_VAR_SF	Reactive Power scale factor		int16be	1	1	0		level		false	false	false	
+40092	1	I_AC_PF	Power Factor	%	int16be	1	1	0		level		false	false	false	
+40093	1	I_AC_PF_SF	Power Factor scale factor		int16be	1	1	0		level		false	false	false	
+40094	1	I_AC_Energy_WH	AC Lifetime Energy production	Wh	uint32be	2	1	0		level		true	false	false	
+40096	1	I_AC_Energy_WH_SF	AC Lifetime Energy Scale factor		int16be	1	1	0		level		true	false	false	
+40097	1	I_DC_Current	DC Current value	A	uint16be	1	1	0		level		false	false	false	
+40098	1	I_DC_Current_SF	DC Current scale factor		int16be	1	1	0		level		false	false	false	
+40099	1	I_DC_Voltage	DC Voltage value	V	uint16be	1	1	0		level		false	false	false	
+40100	1	I_DC_Voltage_SF	DC Voltage scale factor		int16be	1	1	0		level		false	false	false	
+40101	1	I_DC_Power	DC Power value	W	int16be	1	1	0	x*Math.pow(10,sf['40102'])	level		true	false	false	
+40102	1	I_DC_Power_SF	DC Power scale factor		int16be	1	1	0		level		true	false	false	true
+40104	1	I_Temp_Sink	Heat Sink Temperature	C°	int16be	1	1	0	x*Math.pow(10,sf['40107'])	level		true	false	false	
+40107	1	I_Temp_SF	Heat Sink Temperature scale factor		int16be	1	1	0		level		true	false	false	true
+40108	1	I_Status	Operating State		uint16be	1	1	0		level		true	false	false	
+40109	1	I_Status_Vendor	Vendor-defined operating state and error codes		uint16be	1	1	0		level		true	false	false	
+40207	1	M_AC_Power	Total Real Power	W	int16be	1	1	0	x*Math.pow(10,sf['40211'])	level		true	false	false	
+40208	1	M_AC_Power_A		W	int16be	1	1	0	x*Math.pow(10,sf['40211'])	level		true	false	false	
+40209	1	M_AC_Power_B		W	int16be	1	1	0	x*Math.pow(10,sf['40211'])	level		true	false	false	
+40210	1	M_AC_Power_C		W	int16be	1	1	0	x*Math.pow(10,sf['40211'])	level		true	false	false	
+40211	1	M_AC_Power_SF	Total Real Power scale factor		int16be	1	1	0		level		true	false	false	true
+40227	1	M_Exported		W	uint32be	2	1	0		level		true	false	false	
+40235	1	M_Imported		W	uint32be	2	1	0		level		true	false	false	
+40243	1	M_Energy_W_SF	Real Energy Scale Factor		int16be	1	1	0		level		true	false	false	
+40005	2	C_Manufacturer	Inverter Manufacturer		string	16	1	0		level		false	false	false	
+40021	2	C_Model	Inverter Model		string	16	1	0		level		false	false	false	
+40045	2	C_Version	Inverter Version		string	8	1	0		level		true	false	false	
+40053	2	C_SerialNumber	Inverter Serial Number		string	16	1	0		level		false	false	false	
+40069	2	C_DeviceAddress	MODBUS Unit ID		uint16be	1	1	0		level		false	false	false	
+40070	2	C_SunSpec_DID	Phases		uint16be	1	1	0		level		false	false	false	
+40072	2	I_AC_Current	AC Current	A	uint16be	1	1	0		level		false	false	false	
+40073	2	I_AC_CurrentA	AC Phase A Current value	A	uint16be	1	1	0		level		false	false	false	
+40074	2	I_AC_CurrentB	AC Phase B Current value	A	uint16be	1	1	0		level		false	false	false	
+40075	2	I_AC_CurrentC	AC Phase C Current value	A	uint16be	1	1	0		level		false	false	false	
+40076	2	I_AC_Current_SF	AC Current scale factor		int16be	1	1	0		level		false	false	false	
+40080	2	I_AC_VoltageAN	AC Voltage Phase A to N value		uint16be	1	1	0		level		false	false	false	
+40081	2	I_AC_VoltageBN	AC Voltage Phase B to N value		uint16be	1	1	0		level		false	false	false	
+40082	2	I_AC_VoltageCN	AC Voltage Phase C to N value		uint16be	1	1	0		level		false	false	false	
+40083	2	I_AC_Voltage_SF	AC Voltage scale factor		int16be	1	1	0		level		false	false	false	
+40084	2	I_AC_Power	AC Power value	W	int16be	1	1	0	x*Math.pow(10,sf['40085'])	level		true	false	false	
+40085	2	I_AC_Power_SF	AC Power scale factor		int16be	1	1	0		level		true	false	false	true
+40086	2	I_AC_Frequency	AC Frequency value	Hz	uint16be	1	1	0		level		false	false	false	
+40087	2	I_AC_Frequency_SF	AC Frequency scale factor		int16be	1	1	0		level		false	false	false	
+40088	2	I_AC_VA	Apparent Power value	VA	int16be	1	1	0		level		false	false	false	
+40089	2	I_AC_VA_SF	Apparent Power scale factor		int16be	1	1	0		level		false	false	false	
+40090	2	I_AC_VAR	Reactive Power	VAR	int16be	1	1	0		level		false	false	false	
+40091	2	I_AC_VAR_SF	Reactive Power scale factor		int16be	1	1	0		level		false	false	false	
+40092	2	I_AC_PF	Power Factor	%	int16be	1	1	0		level		false	false	false	
+40093	2	I_AC_PF_SF	Power Factor scale factor		int16be	1	1	0		level		false	false	false	
+40094	2	I_AC_Energy_WH	AC Lifetime Energy production	Wh	uint32be	2	1	0		level		true	false	false	
+40096	2	I_AC_Energy_WH_SF	AC Lifetime Energy production scale factor		uint16be	1	1	0		level		true	false	false	
+40097	2	I_DC_Current	DC Current value	A	uint16be	1	1	0		level		false	false	false	
+40098	2	I_DC_Current_SF	DC Current scale factor		int16be	1	1	0		level		false	false	false	
+40099	2	I_DC_Voltage	DC Voltage value	V	uint16be	1	1	0		level		false	false	false	
+40100	2	I_DC_Voltage_SF	DC Voltage scale factor		int16be	1	1	0		level		false	false	false	
+40101	2	I_DC_Power	DC Power value	W	int16be	1	1	0	x*Math.pow(10,sf['40102'])	level		true	false	false	
+40102	2	I_DC_Power_SF	DC Power scale factor		int16be	1	1	0		level		true	false	false	true
+40104	2	I_Temp_Sink	Heat Sink Temperature	C°	int16be	1	1	0	x*Math.pow(10,sf['40107'])	level		true	false	false	
+40107	2	I_Temp_SF	Heat Sink Temperature scale factor		int16be	1	1	0		level		true	false	false	true
+40108	2	I_Status	Operating State		uint16be	1	1	0		level		true	false	false	
+40109	2	I_Status_Vendor	Vendor-defined operating state and error codes		uint16be	1	1	0		level		true	false	false	


### PR DESCRIPTION
I have been asked a few times if I can share my SolarEdge holding registers for a hybrid inverter with Home Battery and the associated script for calculating the DC power.